### PR TITLE
Syslog facility

### DIFF
--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -290,9 +290,8 @@ where
             write!(buf, "{}", self.syslog_identifier).unwrap()
         });
         if let Some(facility) = self.syslog_facility {
-            put_field_length_encoded(&mut buf, "SYSLOG_FACILITY", |buf| {
-                write!(buf, "{}", facility).unwrap()
-            });
+            // Text format is safe as a u8 can't possibly contain anything funny
+            writeln!(buf, "SYSLOG_FACILITY={}", facility).unwrap();
         }
 
         event.record(&mut EventVisitor::new(

--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -169,7 +169,8 @@ impl Subscriber {
     /// and allows filtering log messages by syslog facility with `journalctl
     /// --facility`.
     ///
-    /// See [Journal Fields](https://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html)
+    /// See [Syslog Message Facilities](https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1),
+    /// [Journal Fields](https://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html)
     /// and [journalctl](https://www.freedesktop.org/software/systemd/man/journalctl.html)
     /// for more information.
     ///

--- a/tracing-journald/tests/journal.rs
+++ b/tracing-journald/tests/journal.rs
@@ -223,7 +223,8 @@ fn simple_metadata() {
     let sub = Subscriber::new()
         .unwrap()
         .with_field_prefix(None)
-        .with_syslog_identifier("test_ident".to_string());
+        .with_syslog_identifier("test_ident".to_string())
+        .with_syslog_facility(18);
     with_journald_subscriber(sub, || {
         info!(test.name = "simple_metadata", "Hello World");
 
@@ -232,6 +233,7 @@ fn simple_metadata() {
         assert_eq!(message["PRIORITY"], "5");
         assert_eq!(message["TARGET"], "journal");
         assert_eq!(message["SYSLOG_IDENTIFIER"], "test_ident");
+        assert_eq!(message["SYSLOG_FACILITY"], "18");
         assert!(message["CODE_FILE"].as_text().is_some());
         assert!(message["CODE_LINE"].as_text().is_some());
     });


### PR DESCRIPTION
- Change facility type to `u8` and remove `>> 3`, to be in compliance with the [official values](https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1).
- Add link to official syslog facilities specification in docstring
- Add test